### PR TITLE
Remove wallet connection text from loading modal

### DIFF
--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -22,11 +22,6 @@ export default function LoadingModal({ isOpen, message = "Connecting to wallet..
           <p className="text-gray-700 dark:text-gray-300 text-center font-medium">
             {message}
           </p>
-          
-          {/* Additional info */}
-          <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
-            Please wait while we connect your wallet
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Removes the redundant "Please wait while we connect your wallet" text from the loading modal.

## Changes
- Removed the static wallet connection text that appeared below the dynamic message in the LoadingModal component
- The modal now only displays the message passed to it (e.g., "Processing transaction...")

## Test plan
- [x] Verified the loading modal displays correctly when processing transactions
- [x] Confirmed no wallet connection text appears in the modal
- [x] Tested that the dynamic message still appears properly